### PR TITLE
state_polygons to match previous chunk in readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -93,7 +93,7 @@ Let's visualise the data using the `ggplot2` package.
 # If you don't have the package you can install it with `install.packages("ggplot2")`.
 library(ggplot2)
 ggplot(public_toilets) +
-  geom_sf(data = state_shp, fill = "antiquewhite") +
+  geom_sf(data = state_polygons, fill = "antiquewhite") +
   geom_sf(alpha = 0.05, aes(color = status)) +
   labs(title = "Public toilets in Australia, 2017") +
   scale_color_brewer(palette = "Dark2") +

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Let’s visualise the data using the `ggplot2` package.
 # If you don't have the package you can install it with `install.packages("ggplot2")`.
 library(ggplot2)
 ggplot(public_toilets) +
-  geom_sf(data = state_shp, fill = "antiquewhite") +
+  geom_sf(data = state_polygons, fill = "antiquewhite") +
   geom_sf(alpha = 0.05, aes(color = status)) +
   labs(title = "Public toilets in Australia, 2017") +
   scale_color_brewer(palette = "Dark2") +


### PR DESCRIPTION
The ggplot in readme should use `state_polygons` (generated in previous chunk) instead of `state_shp` (does not exist). This fixes it.